### PR TITLE
Feature/multiple targets

### DIFF
--- a/generamba/lib/generamba/cli/gen_command.rb
+++ b/generamba/lib/generamba/cli/gen_command.rb
@@ -8,9 +8,11 @@ module Generamba::CLI
 
     desc 'gen [MODULE_NAME] [TEMPLATE_NAME]', 'Creates a new VIPER module with a given name from a specific template'
     method_option :description, :aliases => '-d', :desc => 'Provides a full description to the module'
+    method_option :module_targets, :desc => 'Specifies project targets for adding new module files'
     method_option :module_file_path, :desc => 'Specifies a location in the filesystem for new files'
     method_option :module_group_path, :desc => 'Specifies a location in Xcode groups for new files'
     method_option :module_path, :desc => 'Specifies a location (both in the filesystem and Xcode) for new files'
+    method_option :test_targets, :desc => 'Specifies project targets for adding new test files'
     method_option :test_file_path, :desc => 'Specifies a location in the filesystem for new test files'
     method_option :test_group_path, :desc => 'Specifies a location in Xcode groups for new test files'
     method_option :test_path, :desc => 'Specifies a location (both in the filesystem and Xcode) for new test files'

--- a/generamba/lib/generamba/code_generation/code_module.rb
+++ b/generamba/lib/generamba/code_generation/code_module.rb
@@ -15,6 +15,9 @@ module Generamba
       @name = name
       @description = description
 
+      @project_targets = options[:module_targets].split(',') if options[:module_targets]
+      @test_targets = options[:test_targets].split(',') if options[:test_targets]
+
       @module_file_path = Pathname.new(options[:module_file_path]) if options[:module_file_path]
       @module_group_path = Pathname.new(options[:module_group_path]) if options[:module_group_path]
       @test_file_path = Pathname.new(options[:test_file_path]) if options[:test_file_path]
@@ -84,6 +87,11 @@ module Generamba
       if ProjectConfiguration.project_targets != nil
         targets = ProjectConfiguration.project_targets
       end
+
+      if @project_targets != nil
+        targets = @project_targets
+      end
+
       return targets
     end
 
@@ -96,6 +104,11 @@ module Generamba
       if ProjectConfiguration.test_targets != nil
         targets = ProjectConfiguration.test_targets
       end
+
+      if @test_targets != nil
+        targets = @test_targets
+      end
+
       return targets
     end
   end

--- a/generamba/lib/generamba/code_generation/code_module.rb
+++ b/generamba/lib/generamba/code_generation/code_module.rb
@@ -65,17 +65,27 @@ module Generamba
     end
 
     def test_file_path
-      return @test_file_path != nil ?
-          @test_file_path :
-          Pathname.new(ProjectConfiguration.test_file_path)
-              .join(@name)
+      if @test_file_path == nil
+        if ProjectConfiguration.test_file_path == nil
+          return nil
+        end
+
+        return Pathname.new(ProjectConfiguration.test_file_path)
+                   .join(@name)
+      end
+      return @test_file_path
     end
 
     def test_group_path
-      return @test_group_path != nil ?
-          @test_group_path :
-          Pathname.new(ProjectConfiguration.test_group_path)
-              .join(@name)
+      if @test_group_path == nil
+        if ProjectConfiguration.test_group_path == nil
+          return nil
+        end
+
+        return Pathname.new(ProjectConfiguration.test_group_path)
+                   .join(@name)
+      end
+      return @test_group_path
     end
 
     def project_targets

--- a/generamba/lib/generamba/code_generation/code_module.rb
+++ b/generamba/lib/generamba/code_generation/code_module.rb
@@ -2,7 +2,14 @@ module Generamba
 
   # Represents currently generating code module
   class CodeModule
-    attr_reader :name, :description, :module_file_path, :module_group_path, :test_file_path, :test_group_path
+    attr_reader :name,
+                :description,
+                :module_file_path,
+                :module_group_path,
+                :test_file_path,
+                :test_group_path,
+                :project_targets,
+                :test_targets
 
     def initialize(name, description, options)
       @name = name
@@ -68,5 +75,28 @@ module Generamba
               .join(@name)
     end
 
+    def project_targets
+      targets = Array.new
+      if ProjectConfiguration.project_target != nil
+        targets = [ProjectConfiguration.project_target]
+      end
+
+      if ProjectConfiguration.project_targets != nil
+        targets = ProjectConfiguration.project_targets
+      end
+      return targets
+    end
+
+    def test_targets
+      targets = Array.new
+      if ProjectConfiguration.test_target != nil
+        targets = [ProjectConfiguration.test_target]
+      end
+
+      if ProjectConfiguration.test_targets != nil
+        targets = ProjectConfiguration.test_targets
+      end
+      return targets
+    end
   end
 end

--- a/generamba/lib/generamba/code_generation/code_module.rb
+++ b/generamba/lib/generamba/code_generation/code_module.rb
@@ -2,8 +2,7 @@ module Generamba
 
   # Represents currently generating code module
   class CodeModule
-    attr_reader :name, :description
-    attr_accessor :module_file_path, :module_group_path, :test_file_path, :test_group_path
+    attr_reader :name, :description, :module_file_path, :module_group_path, :test_file_path, :test_group_path
 
     def initialize(name, description, options)
       @name = name

--- a/generamba/lib/generamba/configuration/project_configuration.rb
+++ b/generamba/lib/generamba/configuration/project_configuration.rb
@@ -5,5 +5,6 @@ module Generamba
   # A singletone class representing a Rambafile of the current project
   class ProjectConfiguration < Settingslogic
     source Dir.getwd + '/' + RAMBAFILE_NAME
+    suppress_errors(true)
   end
 end

--- a/generamba/lib/generamba/constants/rambafile_constants.rb
+++ b/generamba/lib/generamba/constants/rambafile_constants.rb
@@ -7,10 +7,12 @@ module Generamba
   XCODEPROJ_PATH_KEY = 'xcodeproj_path'
 
   PROJECT_TARGET_KEY = 'project_target'
+  PROJECT_TARGETS_KEY = 'project_targets'
   PROJECT_FILE_PATH_KEY = 'project_file_path'
   PROJECT_GROUP_PATH_KEY = 'project_group_path'
 
   TEST_TARGET_KEY = 'test_target'
+  TEST_TARGETS_KEY = 'test_targets'
   TEST_FILE_PATH_KEY = 'test_file_path'
   TEST_GROUP_PATH_KEY = 'test_group_path'
 

--- a/generamba/lib/generamba/helpers/rambafile_validator.rb
+++ b/generamba/lib/generamba/helpers/rambafile_validator.rb
@@ -14,8 +14,6 @@ module Generamba
                           XCODEPROJ_PATH_KEY,
                           PROJECT_FILE_PATH_KEY,
                           PROJECT_GROUP_PATH_KEY,
-                          TEST_FILE_PATH_KEY,
-                          TEST_GROUP_PATH_KEY,
                           TEMPLATES_KEY]
 
       interchangable_fields = [[PROJECT_TARGETS_KEY, PROJECT_TARGET_KEY]]

--- a/generamba/lib/generamba/helpers/rambafile_validator.rb
+++ b/generamba/lib/generamba/helpers/rambafile_validator.rb
@@ -12,20 +12,32 @@ module Generamba
       mandatory_fields = [COMPANY_KEY,
                           PROJECT_NAME_KEY,
                           XCODEPROJ_PATH_KEY,
-                          PROJECT_TARGET_KEY,
                           PROJECT_FILE_PATH_KEY,
                           PROJECT_GROUP_PATH_KEY,
-                          TEST_TARGET_KEY,
                           TEST_FILE_PATH_KEY,
                           TEST_GROUP_PATH_KEY,
                           TEMPLATES_KEY]
 
-      mandatory_fields.each { |field|
+      interchangable_fields = [[PROJECT_TARGETS_KEY, PROJECT_TARGET_KEY]]
+
+      mandatory_fields.each do |field|
         if preferences.has_key?(field) == false
           error_description = "Rambafile is broken! Cannot find #{field} field, which is mandatory. Either add it manually, or run *generamba setup*.".red
           raise StandardError.new(error_description)
         end
-      }
+      end
+
+      interchangable_fields.each do |fields_array|
+        has_value = false
+        fields_array.each do |field|
+          has_value = preferences.has_key?(field) || has_value
+        end
+
+        if has_value == false
+          error_description = "Rambafile is broken! Cannot find any of #{fields_array} fields, one of them is mandatory. Either add it manually, or run *generamba setup*.".red
+          raise StandardError.new(error_description)
+        end
+      end
 
       if preferences[TEMPLATES_KEY] == nil
         error_description = "You can't run *generamba gen* without any templates installed. Add their declarations to a Rambafile and run *generamba template install*.".red

--- a/generamba/lib/generamba/helpers/xcodeproj_helper.rb
+++ b/generamba/lib/generamba/helpers/xcodeproj_helper.rb
@@ -71,11 +71,14 @@ module Generamba
     #
     # @return [Xcodeproj::AbstractTarget]
     def self.obtain_target(target_name, project)
-      project.targets.each { |target|
+      project.targets.each do |target|
         if target.name == target_name
           return target
         end
-      }
+      end
+
+      error_description = "Cannot find a target with name #{target_name} in Xcode project".red
+      raise StandardError.new(error_description)
     end
 
     # Splits the provided Xcode group path to an array of separate groups

--- a/generamba/lib/generamba/helpers/xcodeproj_helper.rb
+++ b/generamba/lib/generamba/helpers/xcodeproj_helper.rb
@@ -26,18 +26,20 @@ module Generamba
 
     # Adds a provided file to a specific Project and Target
     # @param project [Xcodeproj::Project] The target xcodeproj file
-    # @param target [AbstractTarget] The target for a file
+    # @param targets [AbstractTarget] Array of tatgets
     # @param group_path [Pathname] The Xcode group path for current file
     # @param file_path [Pathname] The file path for current file
     #
     # @return [void]
-    def self.add_file_to_project_and_target(project, target, group_path, file_path)
+    def self.add_file_to_project_and_targets(project, targets, group_path, file_path)
       module_group = self.retreive_or_create_group(group_path, project)
       xcode_file = module_group.new_file(File.absolute_path(file_path))
 
       file_name = File.basename(file_path)
       if File.extname(file_name) == '.m'
-        target.add_file_references([xcode_file])
+        targets.each do |target|
+          target.add_file_references([xcode_file])
+        end
       end
     end
 

--- a/generamba/lib/generamba/helpers/xcodeproj_helper.rb
+++ b/generamba/lib/generamba/helpers/xcodeproj_helper.rb
@@ -11,19 +11,6 @@ module Generamba
       Xcodeproj::Project.open(project_name)
     end
 
-    # Returns an AbstractTarget class for a given name
-    # @param target_name [String] The name of the target
-    # @param project [Xcodeproj::Project] The target xcodeproj file
-    #
-    # @return [Xcodeproj::AbstractTarget]
-    def self.obtain_target(target_name, project)
-      project.targets.each { |target|
-        if target.name == target_name
-          return target
-        end
-      }
-    end
-
     # Adds a provided file to a specific Project and Target
     # @param project [Xcodeproj::Project] The target xcodeproj file
     # @param targets [AbstractTarget] Array of tatgets
@@ -38,7 +25,8 @@ module Generamba
       file_name = File.basename(file_path)
       if File.extname(file_name) == '.m'
         targets.each do |target|
-          target.add_file_references([xcode_file])
+          xcode_target = self.obtain_target(target, project)
+          xcode_target.add_file_references([xcode_file])
         end
       end
     end
@@ -75,6 +63,19 @@ module Generamba
       end
 
       return final_group
+    end
+
+    # Returns an AbstractTarget class for a given name
+    # @param target_name [String] The name of the target
+    # @param project [Xcodeproj::Project] The target xcodeproj file
+    #
+    # @return [Xcodeproj::AbstractTarget]
+    def self.obtain_target(target_name, project)
+      project.targets.each { |target|
+        if target.name == target_name
+          return target
+        end
+      }
     end
 
     # Splits the provided Xcode group path to an array of separate groups

--- a/generamba/lib/generamba/module_generator.rb
+++ b/generamba/lib/generamba/module_generator.rb
@@ -15,7 +15,10 @@ module Generamba
 			module_dir_path = code_module.module_file_path
 			test_dir_path = code_module.test_file_path
 			FileUtils.mkdir_p module_dir_path
-			FileUtils.mkdir_p test_dir_path
+
+			if test_dir_path != nil
+				FileUtils.mkdir_p test_dir_path
+			end
 
 			# Configuring group paths
 			module_group_path = code_module.module_group_path
@@ -51,7 +54,7 @@ module Generamba
 		def process_files_if_needed(files, name, code_module, template, project, targets, group_path, dir_path)
 			# It's possible that current project doesn't test targets configured, so it doesn't need to generate tests.
 			# The same is for files property - a template can have only test or project files
-			if targets.count == 0 || files.count == 0
+			if targets.count == 0 || files == nil || files.count == 0 || dir_path == nil || group_path == nil
 				return
 			end
 

--- a/generamba/lib/generamba/module_generator.rb
+++ b/generamba/lib/generamba/module_generator.rb
@@ -10,10 +10,6 @@ module Generamba
 		def generate_module(name, code_module, template)
 			# Setting up Xcode objects
 			project = XcodeprojHelper.obtain_project(ProjectConfiguration.xcodeproj_path)
-			project_target = XcodeprojHelper.obtain_target(ProjectConfiguration.project_target,
-																										 project)
-			test_target = XcodeprojHelper.obtain_target(ProjectConfiguration.test_target,
-																									project)
 
 			# Configuring file paths
 			module_dir_path = code_module.module_file_path
@@ -32,7 +28,7 @@ module Generamba
 									 	code_module,
 									 	template,
 										project,
-									 	project_target,
+									 	code_module.project_targets,
 										module_group_path,
 										module_dir_path)
 
@@ -43,7 +39,7 @@ module Generamba
 										code_module,
 										template,
 										project,
-										test_target,
+										code_module.test_targets,
 										test_group_path,
 										test_dir_path)
 
@@ -52,7 +48,7 @@ module Generamba
 			puts("Module #{name} successfully created!".green)
 		end
 
-		def process_files(files, name, code_module, template, project, target, group_path, dir_path)
+		def process_files(files, name, code_module, template, project, targets, group_path, dir_path)
 			XcodeprojHelper.clear_group(project, group_path)
 			files.each do |file|
 				# The target file's name consists of three parameters: project prefix, module name and template file name.
@@ -78,8 +74,8 @@ module Generamba
 				end
 
 				# Creating the file in the Xcode project
-				XcodeprojHelper.add_file_to_project_and_target(project,
-																											 target,
+				XcodeprojHelper.add_file_to_project_and_targets(project,
+																											 targets,
 																											 group_path.join(file_group),
 																											 file_path)
 			end

--- a/generamba/lib/generamba/module_generator.rb
+++ b/generamba/lib/generamba/module_generator.rb
@@ -23,32 +23,38 @@ module Generamba
 
 			# Creating code files
 			puts('Creating code files...')
-			process_files(template.code_files,
-										name,
-									 	code_module,
-									 	template,
-										project,
-									 	code_module.project_targets,
-										module_group_path,
-										module_dir_path)
+			process_files_if_needed(template.code_files,
+															name,
+															code_module,
+															template,
+															project,
+															code_module.project_targets,
+															module_group_path,
+															module_dir_path)
 
 			# Creating test files
 			puts('Creating test files...')
-			process_files(template.test_files,
-										name,
-										code_module,
-										template,
-										project,
-										code_module.test_targets,
-										test_group_path,
-										test_dir_path)
+			process_files_if_needed(template.test_files,
+															name,
+															code_module,
+															template,
+															project,
+															code_module.test_targets,
+															test_group_path,
+															test_dir_path)
 
 			# Saving the current changes in the Xcode project
 			project.save
 			puts("Module #{name} successfully created!".green)
 		end
 
-		def process_files(files, name, code_module, template, project, targets, group_path, dir_path)
+		def process_files_if_needed(files, name, code_module, template, project, targets, group_path, dir_path)
+			# It's possible that current project doesn't test targets configured, so it doesn't need to generate tests.
+			# The same is for files property - a template can have only test or project files
+			if targets.count == 0 || files.count == 0
+				return
+			end
+
 			XcodeprojHelper.clear_group(project, group_path)
 			files.each do |file|
 				# The target file's name consists of three parameters: project prefix, module name and template file name.


### PR DESCRIPTION
This PR changes the way Generamba adds new files:
- Besides two auto-generated Rambafile fields: `project_target` and `module_target`, we can now specify its analogs: `project_targets` and `module_targets`, which are arrays. These fields won't be autogenerated by `gneramba setup`, but I'd mention them in docs.
- Generamba can add files to more than one target, using either corresponding fields in the Rambafile, or special flags.
- Two new options are added to `generamba gen` command, which allows to specify module and test targets for the current command run.
- Generamba now correctly handles templates with only module or test templates.
- Generamba now correctly handles Rambafile without unit tests information.

See #11 and #37 for more details.
