### PR TITLE
Feature/template catalog commands

### DIFF
--- a/generamba/lib/generamba/cli/template/template_group.rb
+++ b/generamba/lib/generamba/cli/template/template_group.rb
@@ -1,6 +1,7 @@
 require 'generamba/cli/template/template_install_command.rb'
 require 'generamba/cli/template/template_create_command.rb'
 require 'generamba/cli/template/template_list_command.rb'
+require 'generamba/cli/template/template_search_command.rb'
 
 module Generamba::CLI
   class Application < Thor

--- a/generamba/lib/generamba/cli/template/template_group.rb
+++ b/generamba/lib/generamba/cli/template/template_group.rb
@@ -1,5 +1,6 @@
 require 'generamba/cli/template/template_install_command.rb'
 require 'generamba/cli/template/template_create_command.rb'
+require 'generamba/cli/template/template_list_command.rb'
 
 module Generamba::CLI
   class Application < Thor

--- a/generamba/lib/generamba/cli/template/template_list_command.rb
+++ b/generamba/lib/generamba/cli/template/template_list_command.rb
@@ -1,0 +1,28 @@
+require 'git'
+
+module Generamba::CLI
+  class Template < Thor
+    include Generamba
+
+    desc 'list', 'Prints out the list of all templates available in the shared GitHub catalog'
+    def list
+      catalog_local_path = Pathname.new(ENV['HOME'])
+                               .join(GENERAMBA_HOME_DIR)
+                               .join(CATALOGS_DIR)
+      FileUtils.rm_rf catalog_local_path
+      FileUtils.mkdir_p catalog_local_path
+
+      Git.clone(RAMBLER_CATALOG_REPO, GENERAMBA_CATALOG_NAME, :path => catalog_local_path)
+
+      generamba_catalog_path = catalog_local_path.join(GENERAMBA_CATALOG_NAME)
+
+      generamba_catalog_path.children.select { |child|
+        child.directory? && child.split.last.to_s[0] != '.'
+      }.map { |template_path|
+        template_path.split.last.to_s
+      }.each { |template_name|
+        puts(template_name)
+      }
+    end
+  end
+end

--- a/generamba/lib/generamba/cli/template/template_list_command.rb
+++ b/generamba/lib/generamba/cli/template/template_list_command.rb
@@ -1,4 +1,4 @@
-require 'git'
+require 'generamba/template/helpers/catalog_downloader.rb'
 
 module Generamba::CLI
   class Template < Thor
@@ -6,15 +6,8 @@ module Generamba::CLI
 
     desc 'list', 'Prints out the list of all templates available in the shared GitHub catalog'
     def list
-      catalog_local_path = Pathname.new(ENV['HOME'])
-                               .join(GENERAMBA_HOME_DIR)
-                               .join(CATALOGS_DIR)
-      FileUtils.rm_rf catalog_local_path
-      FileUtils.mkdir_p catalog_local_path
-
-      Git.clone(RAMBLER_CATALOG_REPO, GENERAMBA_CATALOG_NAME, :path => catalog_local_path)
-
-      generamba_catalog_path = catalog_local_path.join(GENERAMBA_CATALOG_NAME)
+      downloader = CatalogDownloader.new
+      generamba_catalog_path = downloader.download_catalog(GENERAMBA_CATALOG_NAME, RAMBLER_CATALOG_REPO)
 
       generamba_catalog_path.children.select { |child|
         child.directory? && child.split.last.to_s[0] != '.'

--- a/generamba/lib/generamba/cli/template/template_search_command.rb
+++ b/generamba/lib/generamba/cli/template/template_search_command.rb
@@ -1,4 +1,4 @@
-require 'git'
+require 'generamba/template/helpers/catalog_downloader.rb'
 
 module Generamba::CLI
   class Template < Thor
@@ -6,15 +6,8 @@ module Generamba::CLI
 
     desc 'search', 'Searches a template with a given name in the shared GitHub catalog'
     def search(term)
-      catalog_local_path = Pathname.new(ENV['HOME'])
-                               .join(GENERAMBA_HOME_DIR)
-                               .join(CATALOGS_DIR)
-      FileUtils.rm_rf catalog_local_path
-      FileUtils.mkdir_p catalog_local_path
-
-      Git.clone(RAMBLER_CATALOG_REPO, GENERAMBA_CATALOG_NAME, :path => catalog_local_path)
-
-      generamba_catalog_path = catalog_local_path.join(GENERAMBA_CATALOG_NAME)
+      downloader = CatalogDownloader.new
+      generamba_catalog_path = downloader.download_catalog(GENERAMBA_CATALOG_NAME, RAMBLER_CATALOG_REPO)
 
       generamba_catalog_path.children.select { |child|
         child.directory? && child.split.last.to_s[0] != '.'

--- a/generamba/lib/generamba/cli/template/template_search_command.rb
+++ b/generamba/lib/generamba/cli/template/template_search_command.rb
@@ -15,6 +15,10 @@ module Generamba::CLI
         template_path.split.last.to_s
       }.select { |template_name|
         template_name.include?(term)
+      }.map { |template_name|
+        keywords = term.squeeze.strip.split(' ').compact.uniq
+        matcher = Regexp.new('(' + keywords.join('|') + ')')
+        template_name.gsub(matcher) { |match| "#{match}".yellow }
       }.each { |template_name|
         puts(template_name)
       }

--- a/generamba/lib/generamba/cli/template/template_search_command.rb
+++ b/generamba/lib/generamba/cli/template/template_search_command.rb
@@ -4,7 +4,7 @@ module Generamba::CLI
   class Template < Thor
     include Generamba
 
-    desc 'search', 'Searches a template with a given name in the shared GitHub catalog'
+    desc 'search [SEARCH_STRING]', 'Searches a template with a given name in the shared GitHub catalog'
     def search(term)
       downloader = CatalogDownloader.new
       generamba_catalog_path = downloader.download_catalog(GENERAMBA_CATALOG_NAME, RAMBLER_CATALOG_REPO)

--- a/generamba/lib/generamba/cli/template/template_search_command.rb
+++ b/generamba/lib/generamba/cli/template/template_search_command.rb
@@ -1,0 +1,30 @@
+require 'git'
+
+module Generamba::CLI
+  class Template < Thor
+    include Generamba
+
+    desc 'search', 'Searches a template with a given name in the shared GitHub catalog'
+    def search(term)
+      catalog_local_path = Pathname.new(ENV['HOME'])
+                               .join(GENERAMBA_HOME_DIR)
+                               .join(CATALOGS_DIR)
+      FileUtils.rm_rf catalog_local_path
+      FileUtils.mkdir_p catalog_local_path
+
+      Git.clone(RAMBLER_CATALOG_REPO, GENERAMBA_CATALOG_NAME, :path => catalog_local_path)
+
+      generamba_catalog_path = catalog_local_path.join(GENERAMBA_CATALOG_NAME)
+
+      generamba_catalog_path.children.select { |child|
+        child.directory? && child.split.last.to_s[0] != '.'
+      }.map { |template_path|
+        template_path.split.last.to_s
+      }.select { |template_name|
+        template_name.include?(term)
+      }.each { |template_name|
+        puts(template_name)
+      }
+    end
+  end
+end

--- a/generamba/lib/generamba/template/helpers/catalog_downloader.rb
+++ b/generamba/lib/generamba/template/helpers/catalog_downloader.rb
@@ -1,0 +1,27 @@
+require 'git'
+
+module Generamba
+
+  # Provides the functionality to download template catalogs from the remote repository
+  class CatalogDownloader
+
+    # Clones a template catalog from a remote repository
+    #
+    # @param name [String] The name of the template catalog
+    # @param url [String] The url of the repository
+    #
+    # @return [Pathname] A filepath to the downloaded catalog
+    def download_catalog(name, url)
+      catalog_local_path = Pathname.new(ENV['HOME'])
+                               .join(GENERAMBA_HOME_DIR)
+                               .join(CATALOGS_DIR)
+      FileUtils.rm_rf catalog_local_path
+      FileUtils.mkdir_p catalog_local_path
+
+      Git.clone(url, name, :path => catalog_local_path)
+
+      return catalog_local_path
+                 .join(name)
+    end
+  end
+end

--- a/generamba/lib/generamba/template/processor/template_processor.rb
+++ b/generamba/lib/generamba/template/processor/template_processor.rb
@@ -2,6 +2,7 @@ require 'generamba/template/processor/template_declaration.rb'
 require 'generamba/template/installer/local_installer.rb'
 require 'generamba/template/installer/remote_installer.rb'
 require 'generamba/template/installer/catalog_installer.rb'
+require 'generamba/template/helpers/catalog_downloader.rb'
 require 'git'
 
 module Generamba
@@ -51,13 +52,8 @@ module Generamba
 
       puts('Updating shared generamba-catalog specs...')
 
-      catalog_local_path = Pathname.new(ENV['HOME'])
-                               .join(GENERAMBA_HOME_DIR)
-                               .join(CATALOGS_DIR)
-      FileUtils.rm_rf catalog_local_path
-      FileUtils.mkdir_p catalog_local_path
-
-      Git.clone(RAMBLER_CATALOG_REPO, GENERAMBA_CATALOG_NAME, :path => catalog_local_path)
+      downloader = CatalogDownloader.new
+      downloader.download_catalog(GENERAMBA_CATALOG_NAME, RAMBLER_CATALOG_REPO)
     end
 
     # Provides the appropriate strategy for a given template type


### PR DESCRIPTION
I've added two _not very useful_ commands:
- `generamba template list`
- `generamba template search`

These commands are currently used only with the [shared template catalog](https://github.com/rambler-ios/generamba-catalog).

See #25 and #26 dor more details.
