### PR TITLE
Fixed crash when templates directory exists.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    generamba (0.7.1)
+    generamba (0.7.2)
       git (= 1.2.9.1)
       liquid (= 3.0.6)
       thor (= 0.19.1)

--- a/lib/generamba/template/helpers/catalog_downloader.rb
+++ b/lib/generamba/template/helpers/catalog_downloader.rb
@@ -18,7 +18,12 @@ module Generamba
       current_catalog_path = catalogs_local_path
                                  .join(name)
 
-      Git.clone(url, name, :path => catalogs_local_path)
+      if File.exists? current_catalog_path
+        g = Git.open(current_catalog_path)
+        g.pull
+      else
+        Git.clone(url, name, :path => catalogs_local_path)
+      end
 
       return current_catalog_path
     end

--- a/lib/generamba/template/helpers/catalog_downloader.rb
+++ b/lib/generamba/template/helpers/catalog_downloader.rb
@@ -18,7 +18,7 @@ module Generamba
       current_catalog_path = catalogs_local_path
                                  .join(name)
 
-      if File.exists? current_catalog_path
+      if File.exists?(current_catalog_path)
         g = Git.open(current_catalog_path)
         g.pull
       else

--- a/spec/catalog_downloader_spec.rb
+++ b/spec/catalog_downloader_spec.rb
@@ -2,9 +2,28 @@ require 'spec_helper'
 
 describe 'CatalogDownloader' do
   describe 'method download_catalog' do
-    it 'should clone catalog from remote repository' do
+
+    it 'should pull catalog from remote repository if directory exists' do
       catalog_name = 'catalog'
       catalog_url = 'https://github.com/rambler-ios/generamba-catalog'
+
+      allow(File).to receive(:exists?) { true }
+
+      git = instance_double("Base")
+
+      allow(Git).to receive(:open) { git }
+      allow(git).to receive(:pull)
+      expect(git).to receive(:pull)
+
+      downloader = Generamba::CatalogDownloader.new
+      downloader.download_catalog(catalog_name, catalog_url)
+    end
+
+    it 'should clone catalog from remote repository if directory not exists' do
+      catalog_name = 'catalog'
+      catalog_url = 'https://github.com/rambler-ios/generamba-catalog'
+
+      allow(File).to receive(:exists?) { false }
 
       allow(Git).to receive(:clone)
       expect(Git).to receive(:clone).with(catalog_url, catalog_name, any_args)


### PR DESCRIPTION
Crash occurs via `generamna template list` when templates directory was created previously.
