### PR TITLE
New "file_name" property for template files in rambaspec

### DIFF
--- a/lib/generamba/code_generation/content_generator.rb
+++ b/lib/generamba/code_generation/content_generator.rb
@@ -16,9 +16,9 @@ module Generamba
 			Liquid::Template.file_system = Liquid::LocalFileSystem.new(template.template_path.join('snippets'), '%s.liquid')
 
 			template = Liquid::Template.parse(file_source)
-            filename_template = self.file_name_template(file)
+			filename_template = self.file_name_template(file)
       
-            file_basename = File.basename(file[TEMPLATE_FILE_NAME_KEY])
+			file_basename = File.basename(file[TEMPLATE_FILE_NAME_KEY])
 
 			module_info = {
 					'name' => code_module.name,
@@ -41,22 +41,22 @@ module Generamba
 					'prefix' => code_module.prefix
 			}
       
-            module_info['file_basename'] = file_basename
+			module_info['file_basename'] = file_basename
 
-            file_name = filename_template.render(scope)
+			file_name = filename_template.render(scope)
 
-            module_info['file_name'] = file_name
-            module_info.delete('file_basename')
+			module_info['file_name'] = file_name
+			module_info.delete('file_basename')
 
 			content = template.render(scope)
 
 			return file_name, content
 		end
     
-        def self.file_name_template(file)
-            template_default_text = "{{ prefix }}{{ module_info.name }}{{ module_info.file_basename }}"
-            template_text = file[TEMPLATE_FLIE_FILENAME_KEY] || template_default_text
-            return Liquid::Template.parse(template_text) 
-        end
+		def self.file_name_template(file)
+			template_default_text = "{{ prefix }}{{ module_info.name }}{{ module_info.file_basename }}"
+			template_text = file[TEMPLATE_FLIE_FILENAME_KEY] || template_default_text
+			return Liquid::Template.parse(template_text)
+		end
 	end
 end

--- a/lib/generamba/code_generation/content_generator.rb
+++ b/lib/generamba/code_generation/content_generator.rb
@@ -5,7 +5,7 @@ module Generamba
   # Responsible for generating code using provided liquid templates
 	class ContentGenerator
 
-    # Generates and returns a body of a specific code file.
+    # Generates and returns a filename and a body of a specific code file.
     # @param file []Hash<String,String>] A hashmap with template's filename and filepath
     # @param code_module [CodeModule] The model describing a generating module
     # @param template [ModuleTemplate] The model describing a Generamba template used for code generation

--- a/lib/generamba/code_generation/content_generator.rb
+++ b/lib/generamba/code_generation/content_generator.rb
@@ -55,7 +55,7 @@ module Generamba
     
 		def self.file_name_template(file)
 			template_default_text = "{{ prefix }}{{ module_info.name }}{{ module_info.file_basename }}"
-			template_text = file[TEMPLATE_FLIE_FILENAME_KEY] || template_default_text
+			template_text = file[TEMPLATE_FILE_FILENAME_KEY] || template_default_text
 			return Liquid::Template.parse(template_text)
 		end
 	end

--- a/lib/generamba/constants/rambaspec_constants.rb
+++ b/lib/generamba/constants/rambaspec_constants.rb
@@ -11,6 +11,7 @@ module Generamba
   TEMPLATE_TEST_FILES_KEY = 'test_files'
   TEMPLATE_FILE_NAME_KEY = 'name'
   TEMPLATE_FILE_PATH_KEY = 'path'
+  TEMPLATE_FLIE_FILENAME_KEY = 'file_name'
 
   TEMPLATE_DEPENDENCIES_KEY = 'dependencies'
 end

--- a/lib/generamba/constants/rambaspec_constants.rb
+++ b/lib/generamba/constants/rambaspec_constants.rb
@@ -11,7 +11,7 @@ module Generamba
   TEMPLATE_TEST_FILES_KEY = 'test_files'
   TEMPLATE_FILE_NAME_KEY = 'name'
   TEMPLATE_FILE_PATH_KEY = 'path'
-  TEMPLATE_FLIE_FILENAME_KEY = 'file_name'
+  TEMPLATE_FILE_FILENAME_KEY = 'file_name'
 
   TEMPLATE_DEPENDENCIES_KEY = 'dependencies'
 end

--- a/lib/generamba/module_generator.rb
+++ b/lib/generamba/module_generator.rb
@@ -67,19 +67,14 @@ module Generamba
 
 			XcodeprojHelper.clear_group(project, targets, group_path)
 			files.each do |file|
-				# The target file's name consists of three parameters: project prefix, module name and template file name.
-				# E.g. RDS + Authorization + Presenter.h = RDSAuthorizationPresenter.h
-				file_basename = name + File.basename(file[TEMPLATE_NAME_KEY])
-				prefix = code_module.prefix
-				file_name = prefix ? prefix + file_basename : file_basename
-
+       
 				file_group = File.dirname(file[TEMPLATE_NAME_KEY])
 
-				# Generating the content of the code file
-				file_content = ContentGenerator.create_file_content(file, code_module, template)
+				# Generating the content of the code file and it's name
+				file_name, file_content = ContentGenerator.create_file(file, code_module, template)
 				file_path = dir_path.join(file_group)
 									.join(file_name)
-
+                  
 				# Creating the file in the filesystem
 				FileUtils.mkdir_p File.dirname(file_path)
 				File.open(file_path, 'w+') do |f|


### PR DESCRIPTION
file_name is liquid template string that used to generate filename.
Default value is

```
{{ prefix }}{{ module_info.name }}{{ module_info.file_basename }}
```

All liquid variables are same as for source file, but
- `module_info.file_name` now actual filename and used across code files only
- `module_info.basename` now template's basename and used to generate file_name only
