### PR TITLE
Added ability to add non source files to target

### DIFF
--- a/lib/generamba/constants/rambaspec_constants.rb
+++ b/lib/generamba/constants/rambaspec_constants.rb
@@ -12,6 +12,7 @@ module Generamba
   TEMPLATE_FILE_NAME_KEY = 'name'
   TEMPLATE_FILE_PATH_KEY = 'path'
   TEMPLATE_FILE_FILENAME_KEY = 'file_name'
+  TEMPLATE_FILE_FILETYPE_KEY = 'file_type'
 
   TEMPLATE_DEPENDENCIES_KEY = 'dependencies'
 end

--- a/lib/generamba/helpers/xcodeproj_helper.rb
+++ b/lib/generamba/helpers/xcodeproj_helper.rb
@@ -16,9 +16,10 @@ module Generamba
     # @param targets_name [String] Array of targets name
     # @param group_path [Pathname] The Xcode group path for current file
     # @param file_path [Pathname] The file path for current file
+    # @param file_type is either 'source' or 'resource' - it affects on where file will be added. Put nil for autodetect
     #
     # @return [void]
-    def self.add_file_to_project_and_targets(project, targets_name, group_path, file_path)
+    def self.add_file_to_project_and_targets(project, targets_name, group_path, file_path, file_type = nil)
       module_group = self.retreive_group_or_create_if_needed(group_path, project, true)
       xcode_file = module_group.new_file(File.absolute_path(file_path))
 
@@ -26,12 +27,31 @@ module Generamba
       targets_name.each do |target|
         xcode_target = self.obtain_target(target, project)
 
-        if self.is_compile_source?(file_name)
-          xcode_target.add_file_references([xcode_file])
-        elsif self.is_bundle_resource?(file_name)
-          xcode_target.add_resources([xcode_file])
+        unless file_type
+          if self.is_compile_source?(file_name)
+            file_type = 'source'
+          elsif self.is_bundle_resource?(file_name)
+            file_type = 'resource'
+          end
         end
-
+        
+        self.add_file_to_target(xcode_target, xcode_file, file_type)
+      end
+    end
+    
+    # Adds xcode file to target based on it's type
+    # @param target [Xcodeproj::AbstractTarget] xcode target to use
+    # @param file [Xcodeproj::PBXFileReference] file reference to add
+    # @param type [String] is either 'source' or 'resource'
+    #
+    def self.add_file_to_target(target, file, type)
+      case type
+        when 'source'
+          target.add_file_references([file])
+        when 'resource'
+          target.add_resources([file])
+        else
+          puts "Can't add file with type #{type}. Only 'source' and 'resource' are acceptable"
       end
     end
 

--- a/lib/generamba/module_generator.rb
+++ b/lib/generamba/module_generator.rb
@@ -80,9 +80,11 @@ module Generamba
 				File.open(file_path, 'w+') do |f|
 					f.write(file_content)
 				end
+        
+				file_type = file[TEMPLATE_FILE_FILETYPE_KEY]
 
 				# Creating the file in the Xcode project
-				XcodeprojHelper.add_file_to_project_and_targets(project, targets, group_path.join(file_group), file_path)
+				XcodeprojHelper.add_file_to_project_and_targets(project, targets, group_path.join(file_group), file_path, file_type)
 			end
 		end
 	end


### PR DESCRIPTION
The problem was:
I couldn't add my generated JSON files to Xcode target automatically by generamba.

Solution:
I added "file_type" attribute to files in rambaspec, so now user can specify type of it's file.
