### PR TITLE
Added the possibility to declare custom parameters for code generation

### DIFF
--- a/lib/generamba/cli/gen_command.rb
+++ b/lib/generamba/cli/gen_command.rb
@@ -21,6 +21,7 @@ module Generamba::CLI
     method_option :test_file_path, :desc => 'Specifies a location in the filesystem for new test files'
     method_option :test_group_path, :desc => 'Specifies a location in Xcode groups for new test files'
     method_option :test_path, :desc => 'Specifies a location (both in the filesystem and Xcode) for new test files'
+    method_option :custom_parameters, :type => :hash, :default => {}, :desc => 'Specifies extra parameters in format `key1:value1 key2:value2` for usage during code generation'
     def gen(module_name, template_name)
 
       does_rambafile_exist = Dir[RAMBAFILE_NAME].count > 0

--- a/lib/generamba/code_generation/code_module.rb
+++ b/lib/generamba/code_generation/code_module.rb
@@ -16,7 +16,8 @@ module Generamba
                 :test_group_path,
                 :project_targets,
                 :test_targets,
-                :podfile_path
+                :podfile_path,
+                :custom_parameters
 
     def initialize(name, description, rambafile, options)
       # Base initialization
@@ -47,6 +48,9 @@ module Generamba
 
       @test_targets = [rambafile[TEST_TARGET_KEY]] if rambafile[TEST_TARGET_KEY] != nil
       @test_targets = rambafile[TEST_TARGETS_KEY] if rambafile[TEST_TARGETS_KEY] != nil
+
+      # Custom parameters
+      @custom_parameters = options[:custom_parameters]
 
       # Options adaptation
       @author = options[:author] if options[:author]

--- a/lib/generamba/code_generation/content_generator.rb
+++ b/lib/generamba/code_generation/content_generator.rb
@@ -38,7 +38,8 @@ module Generamba
 					'date' => Time.now.strftime('%d/%m/%Y'),
 					'developer' => developer,
 					'module_info' => module_info,
-					'prefix' => code_module.prefix
+					'prefix' => code_module.prefix,
+					'custom_parameters' => code_module.custom_parameters
 			}
       
 			module_info['file_basename'] = file_basename


### PR DESCRIPTION
Finally implemented #46 - this one was much easier then expected.

Here is how it looks: `generamba gen my_module my_template --custom-parameters=key1:value1 key2:value2`
