### PR TITLE
Feature/carthage support

### DIFF
--- a/lib/generamba/cli/gen_command.rb
+++ b/lib/generamba/cli/gen_command.rb
@@ -51,6 +51,7 @@ module Generamba::CLI
       code_module = CodeModule.new(module_name, module_description, rambafile, options)
 
       DependencyChecker.check_all_required_dependencies_has_in_podfile(template.dependencies, code_module.podfile_path)
+      DependencyChecker.check_all_required_dependencies_has_in_cartfile(template.dependencies, code_module.cartfile_path)
 
       project = XcodeprojHelper.obtain_project(code_module.xcodeproj_path)
       module_group_already_exists = XcodeprojHelper.module_with_group_path_already_exists(project, code_module.module_group_path)

--- a/lib/generamba/code_generation/code_module.rb
+++ b/lib/generamba/code_generation/code_module.rb
@@ -16,7 +16,8 @@ module Generamba
                 :test_group_path,
                 :project_targets,
                 :test_targets,
-                :podfile_path
+                :podfile_path,
+                :cartfile_path
 
     def initialize(name, description, rambafile, options)
       # Base initialization
@@ -65,6 +66,7 @@ module Generamba
       @test_group_path = Pathname.new(options[:test_path]).join(@name) if options[:test_path]
 
       @podfile_path = rambafile[PODFILE_PATH_KEY] if rambafile[PODFILE_PATH_KEY] != nil
+      @cartfile_path = rambafile[CARTFILE_PATH_KEY] if rambafile[CARTFILE_PATH_KEY] != nil
     end
   end
 end

--- a/lib/generamba/helpers/dependency_checker.rb
+++ b/lib/generamba/helpers/dependency_checker.rb
@@ -5,7 +5,7 @@ module Generamba
   # Provides methods for check dependencies from rambaspec in podfile
   class DependencyChecker
 
-    # Check podfile for dependencies
+    # Check Podfile for dependencies
     # @param dependencies [Array] Array of dependencies name
     # @param podfile_path [String] String of Podfile path
     #
@@ -28,6 +28,28 @@ module Generamba
 
       if not_existing_dependency.count > 0
         puts "[Warning] Dependencies #{not_existing_dependency} missed in Podfile".yellow
+      end
+    end
+
+    # Check Cartfile for dependencies
+    # @param dependencies [Array] Array of dependencies name
+    # @param cartfile_path [String] String of Podfile path
+    #
+    # @return [void]
+    def self.check_all_required_dependencies_has_in_cartfile(dependencies, cartfile_path)
+      return if !dependencies or dependencies.count == 0 or !cartfile_path
+
+      cartfile_string = File.read(cartfile_path)
+
+      not_existing_dependency = []
+      dependencies.each do |dependency_name|
+        unless cartfile_string.include?(dependency_name)
+          not_existing_dependency.push(dependency_name)
+        end
+      end
+
+      if not_existing_dependency.count > 0
+        puts "[Warning] Dependencies #{not_existing_dependency} missed in Cartfile".yellow
       end
     end
 

--- a/spec/dependency_checker_spec.rb
+++ b/spec/dependency_checker_spec.rb
@@ -27,4 +27,36 @@ describe 'DependencyChecker' do
     end
   end
 
+  describe 'method check_all_required_dependencies_has_in_cartfile' do
+    it 'should do nothing' do
+      dependencies = ['ViperMcFlurry']
+      cartfile_path = 'Cartfile'
+
+      expect(STDOUT).not_to receive(:puts).with("[Warning] Dependencies #{dependencies} missed in Cartfile".yellow)
+
+      @checker.check_all_required_dependencies_has_in_cartfile(dependencies, nil)
+      @checker.check_all_required_dependencies_has_in_cartfile(nil, cartfile_path)
+    end
+
+    it 'should show warning message if dependency missing' do
+      dependencies = ['ViperMcFlurry']
+      cartfile_path = 'Cartfile'
+
+      allow(File).to receive(:read).and_return('Typhoon')
+      expect(STDOUT).to receive(:puts).with("[Warning] Dependencies #{dependencies} missed in Cartfile".yellow)
+
+      @checker.check_all_required_dependencies_has_in_cartfile(dependencies, cartfile_path)
+    end
+
+    it 'should not show warning message if dependency is in place' do
+      dependencies = ['ViperMcFlurry']
+      cartfile_path = 'Cartfile'
+
+      allow(File).to receive(:read).and_return('github "Rambler-iOS/ViperMcFlurry"')
+      expect(STDOUT).not_to receive(:puts).with("[Warning] Dependencies #{dependencies} missed in Cartfile".yellow)
+
+      @checker.check_all_required_dependencies_has_in_cartfile(dependencies, cartfile_path)
+    end
+  end
+
 end


### PR DESCRIPTION
I've added a simple support of checking dependencies in Cartfile. Generamba loads Cartfile as a string and searches for the occurences of substrings with dependency name inside it. Not a very clever way, but better than nothing.
