### PR TITLE
Feature/gem versions migration

### DIFF
--- a/generamba.gemspec
+++ b/generamba.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'xcodeproj', '0.28.2'
   spec.add_runtime_dependency 'liquid', '3.0.6'
   spec.add_runtime_dependency 'git', '1.2.9.1'
-  spec.add_runtime_dependency 'cocoapods-core', '0.39.0'
+  spec.add_runtime_dependency 'cocoapods-core', '1.0.1'
   spec.add_runtime_dependency 'terminal-table', '1.4.5'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'fakefs', '~> 0.6.1'
   # ActiveSupport dependency is not used by dashramba; instead some other dependency
   # requires it. We lock it to 4.2.7 so as to avoid using 5.0, which is
-  # not compatible with older versions of Ruby. 
+  # not compatible with older versions of Ruby.
   spec.add_development_dependency 'activesupport', '~> 4.2.7'
 end

--- a/generamba.gemspec
+++ b/generamba.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.add_runtime_dependency 'thor', '0.19.1'
-  spec.add_runtime_dependency 'xcodeproj', '0.28.2'
+  spec.add_runtime_dependency 'xcodeproj', '1.2.0'
   spec.add_runtime_dependency 'liquid', '3.0.6'
   spec.add_runtime_dependency 'git', '1.2.9.1'
   spec.add_runtime_dependency 'cocoapods-core', '1.0.1'


### PR DESCRIPTION
PR for Issue #114. From now on Generamba doesn't support old-style `Podfile`.
