### PR TITLE
[RESOLVED] Added more info to `generamba version` command #122

### DIFF
--- a/lib/generamba/cli/version_command.rb
+++ b/lib/generamba/cli/version_command.rb
@@ -7,7 +7,19 @@ module Generamba::CLI
 
     desc 'version', 'Prints out Generamba current version'
     def version
-      puts(Generamba::VERSION.green)
+      options = {}
+      options['Version'] = Generamba::VERSION.green
+      options['Release date'] = Generamba::RELEASE_DATE.green
+      options['Change notes'] = Generamba::RELEASE_LINK.green
+
+      values = []
+
+      options.each do |title, value|
+        values.push("#{title}: #{value}")
+      end
+
+      output = values.join("\n")
+      puts(output)
     end
   end
 end

--- a/lib/generamba/version.rb
+++ b/lib/generamba/version.rb
@@ -1,3 +1,5 @@
 module Generamba
   VERSION = '0.7.8'
+  RELEASE_DATE = '16.05.2016'
+  RELEASE_LINK = "https://github.com/rambler-ios/Generamba/releases/tag/#{VERSION}"
 end


### PR DESCRIPTION
Now output will look:

```
generamba version
Version: 0.7.8
Release date: 16.05.2016
Change notes: https://github.com/rambler-ios/Generamba/releases/tag/0.7.8
```
