### PR TITLE
A little refactoring

### DIFF
--- a/lib/generamba/cli/gen_command.rb
+++ b/lib/generamba/cli/gen_command.rb
@@ -13,7 +13,7 @@ module Generamba::CLI
     desc 'gen [MODULE_NAME] [TEMPLATE_NAME]', 'Creates a new VIPER module with a given name from a specific template'
     method_option :description, :aliases => '-d', :desc => 'Provides a full description to the module'
     method_option :author, :desc => 'Specifies the author name for generated module'
-    method_option :module_targets, :desc => 'Specifies project targets for adding new module files'
+    method_option :project_targets, :desc => 'Specifies project targets for adding new module files'
     method_option :module_file_path, :desc => 'Specifies a location in the filesystem for new files'
     method_option :module_group_path, :desc => 'Specifies a location in Xcode groups for new files'
     method_option :module_path, :desc => 'Specifies a location (both in the filesystem and Xcode) for new files'

--- a/lib/generamba/code_generation/code_module.rb
+++ b/lib/generamba/code_generation/code_module.rb
@@ -57,7 +57,7 @@ module Generamba
 
       # Options adaptation
       @author = options[:author] if options[:author]
-      @project_targets = options[:module_targets].split(',') if options[:module_targets]
+      @project_targets = options[:project_targets].split(',') if options[:project_targets]
       @test_targets = options[:test_targets].split(',') if options[:test_targets]
 
       if options[:module_file_path]
@@ -96,5 +96,6 @@ module Generamba
       @podfile_path = rambafile[PODFILE_PATH_KEY] if rambafile[PODFILE_PATH_KEY] != nil
       @cartfile_path = rambafile[CARTFILE_PATH_KEY] if rambafile[CARTFILE_PATH_KEY] != nil
     end
+
   end
 end

--- a/lib/generamba/code_generation/content_generator.rb
+++ b/lib/generamba/code_generation/content_generator.rb
@@ -56,7 +56,7 @@ module Generamba
     
 		def self.file_name_template(file)
 			template_default_text = "{{ prefix }}{{ module_info.name }}{{ module_info.file_basename }}"
-			template_text = file[TEMPLATE_FILE_FILENAME_KEY] || template_default_text
+			template_text = file[TEMPLATE_FILE_CUSTOM_NAME_KEY] || template_default_text
 			return Liquid::Template.parse(template_text)
 		end
 	end

--- a/lib/generamba/constants/rambaspec_constants.rb
+++ b/lib/generamba/constants/rambaspec_constants.rb
@@ -10,9 +10,9 @@ module Generamba
   TEMPLATE_CODE_FILES_KEY = 'code_files'
   TEMPLATE_TEST_FILES_KEY = 'test_files'
   TEMPLATE_FILE_NAME_KEY = 'name'
+  TEMPLATE_FILE_CUSTOM_NAME_KEY = 'custom_name'
   TEMPLATE_FILE_PATH_KEY = 'path'
-  TEMPLATE_FILE_FILENAME_KEY = 'file_name'
-  TEMPLATE_FILE_FILETYPE_KEY = 'file_type'
+  TEMPLATE_FILE_IS_RESOURCE_KEY = 'is_resource'
 
   TEMPLATE_DEPENDENCIES_KEY = 'dependencies'
 end

--- a/lib/generamba/module_generator.rb
+++ b/lib/generamba/module_generator.rb
@@ -47,15 +47,12 @@ module Generamba
 			# Saving the current changes in the Xcode project
 			project.save
 
-			test_file_path_created_message = !code_module.test_file_path ? "" : "Test file path: #{code_module.test_file_path}".green + "\n"
-			test_group_path_created_message = !code_module.test_group_path ? "" : "Test group path: #{code_module.test_group_path}".green
-
-			puts("Module successfully created!\n" +
-				 "Name: #{name}".green + "\n" +
-				 "Module file path: #{code_module.module_file_path}".green + "\n" +
-				 "Module group path: #{code_module.module_group_path}".green + "\n" +
-				 test_file_path_created_message +
-				 test_group_path_created_message)
+			puts 'Module successfully created!'
+			puts "Name: #{name}".green
+			puts "Module file path: #{code_module.module_file_path}".green
+			puts "Module group path: #{code_module.module_group_path}".green
+			puts !code_module.test_file_path ? '' : "Test file path: #{code_module.test_file_path}".green
+			puts !code_module.test_group_path ? '' : "Test group path: #{code_module.test_group_path}".green
 		end
 
 		def process_files_if_needed(files, name, code_module, template, project, targets, group_path, dir_path)
@@ -73,24 +70,26 @@ module Generamba
 
 					FileUtils.mkdir_p file_group
 					XcodeprojHelper.add_group_to_project(project, file_group)
-				else
-					file_group = File.dirname(file[TEMPLATE_NAME_KEY])
 
-					# Generating the content of the code file and it's name
-					file_name, file_content = ContentGenerator.create_file(file, code_module, template)
-					file_path = dir_path.join(file_group).join(file_name)
-
-					# Creating the file in the filesystem
-					FileUtils.mkdir_p File.dirname(file_path)
-					File.open(file_path, 'w+') do |f|
-						f.write(file_content)
-					end
-
-					file_type = file[TEMPLATE_FILE_FILETYPE_KEY]
-
-					# Creating the file in the Xcode project
-					XcodeprojHelper.add_file_to_project_and_targets(project, targets, group_path.join(file_group), file_path, file_type)
+					next
 				end
+
+				file_group = File.dirname(file[TEMPLATE_NAME_KEY])
+
+				# Generating the content of the code file and it's name
+				file_name, file_content = ContentGenerator.create_file(file, code_module, template)
+				file_path = dir_path.join(file_group).join(file_name)
+
+				# Creating the file in the filesystem
+				FileUtils.mkdir_p File.dirname(file_path)
+				File.open(file_path, 'w+') do |f|
+					f.write(file_content)
+				end
+
+				file_is_resource = file[TEMPLATE_FILE_IS_RESOURCE_KEY]
+
+				# Creating the file in the Xcode project
+				XcodeprojHelper.add_file_to_project_and_targets(project, targets, group_path.join(file_group), file_path, file_is_resource)
 			end
 		end
 	end


### PR DESCRIPTION
1. Replaced gen_command option `module_targets` to `project_targets`.
   Now you can write `generamba gen Module template_name --project_targets Target1,Target2`
2. Replaced rambaspec parameter `file_name` to `custom_name`.
   Now you can write in rambaspec something like this `- {custom_name: "{{ prefix }}{{ custom_parameters.my_value }}{{ module_info.file_basename }}", name: View/ViewInput.h, path: Code/View/view_input.h.liquid}`
3. Replaced rambaspec parameter `file_type` to `is_resource`.
   Now you can write in rambaspec something like this `- {name: Resources/MyJson.json, path: Resources/MyJson.json.liquid, is_resource: true}`. Then generamba adds this file in project like resource, and not like file reference. 
