### PR TITLE
Added product_module_name to code_module

### DIFF
--- a/lib/generamba/code_generation/code_module.rb
+++ b/lib/generamba/code_generation/code_module.rb
@@ -1,7 +1,8 @@
 module Generamba
 
   SLASH_REGEX = /^\/|\/$/
-
+  C99IDENTIFIER = /[^\w]/
+  
   # Represents currently generating code module
   class CodeModule
     attr_reader :name,
@@ -11,6 +12,7 @@ module Generamba
                 :year,
                 :prefix,
                 :project_name,
+                :product_module_name,
                 :xcodeproj_path,
                 :module_file_path,
                 :module_group_path,
@@ -38,6 +40,7 @@ module Generamba
 
       @prefix = rambafile[PROJECT_PREFIX_KEY]
       @project_name = rambafile[PROJECT_NAME_KEY]
+      @product_module_name = rambafile[PRODUCT_MODULE_NAME_KEY] || @project_name.gsub(C99IDENTIFIER, '_')
       @xcodeproj_path = rambafile[XCODEPROJ_PATH_KEY]
 
       @module_file_path = rambafile[PROJECT_FILE_PATH_KEY].gsub(SLASH_REGEX, '')

--- a/lib/generamba/code_generation/content_generator.rb
+++ b/lib/generamba/code_generation/content_generator.rb
@@ -24,6 +24,7 @@ module Generamba
 					'name' => code_module.name,
 					'description' => code_module.description,
 					'project_name' => code_module.project_name,
+                    'product_module_name' => code_module.product_module_name,
 					'project_targets' => code_module.project_targets,
 					'test_targets' => code_module.test_targets
 			}

--- a/lib/generamba/constants/rambafile_constants.rb
+++ b/lib/generamba/constants/rambafile_constants.rb
@@ -12,6 +12,8 @@ module Generamba
   PROJECT_FILE_PATH_KEY = 'project_file_path'
   PROJECT_GROUP_PATH_KEY = 'project_group_path'
 
+  PRODUCT_MODULE_NAME_KEY = 'product_module_name'
+
   TEST_TARGET_KEY = 'test_target'
   TEST_TARGETS_KEY = 'test_targets'
   TEST_FILE_PATH_KEY = 'test_file_path'


### PR DESCRIPTION
I introduced new property `product_module_name`. 
It should be used in swift tests templates. Instead of ~~`@testable import {{ module_info.project_name }}`~~ use `@testable import {{ module_info.product_module_name }}` 
You could set it in Rambafile. If not set, it is calculated from `project_name` via replacing all non [a..zA..Z0..9] characters with `_`.
