### PR TITLE
[RESOLVED] Added ability use custom parameters in rambaspec #128

### DIFF
--- a/lib/generamba/cli/gen_command.rb
+++ b/lib/generamba/cli/gen_command.rb
@@ -4,6 +4,7 @@ require 'generamba/helpers/rambafile_validator.rb'
 require 'generamba/helpers/xcodeproj_helper.rb'
 require 'generamba/helpers/dependency_checker.rb'
 require 'generamba/helpers/gen_command_table_parameters_formatter.rb'
+require 'generamba/helpers/module_info_generator.rb'
 
 module Generamba::CLI
   class Application < Thor
@@ -42,14 +43,15 @@ module Generamba::CLI
 
       rambafile = YAML.load_file(RAMBAFILE_NAME)
 
+      code_module = CodeModule.new(module_name, module_description, rambafile, options)
+      module_info = ModuleInfoGenerator.new(code_module)
+      template = ModuleTemplate.new(template_name, module_info.scope)
+
       parameters = GenCommandTableParametersFormatter.prepare_parameters_for_displaying(rambafile)
       PrintTable.print_values(
           values: parameters,
           title: "Summary for gen #{module_name}"
       )
-
-      template = ModuleTemplate.new(template_name)
-      code_module = CodeModule.new(module_name, module_description, rambafile, options)
 
       DependencyChecker.check_all_required_dependencies_has_in_podfile(template.dependencies, code_module.podfile_path)
       DependencyChecker.check_all_required_dependencies_has_in_cartfile(template.dependencies, code_module.cartfile_path)
@@ -65,7 +67,7 @@ module Generamba::CLI
         end
       end
 
-      generator = Generamba::ModuleGenerator.new()
+      generator = Generamba::ModuleGenerator.new
       generator.generate_module(module_name, code_module, template)
     end
 

--- a/lib/generamba/code_generation/content_generator.rb
+++ b/lib/generamba/code_generation/content_generator.rb
@@ -6,12 +6,12 @@ module Generamba
 	class ContentGenerator
 
     # Generates and returns a filename and a body of a specific code file.
-    # @param file []Hash<String,String>] A hashmap with template's filename and filepath
-    # @param code_module [CodeModule] The model describing a generating module
+    # @param file [Hash<String,String>] A hashmap with template's filename and filepath
+    # @param scope [Hash<String,String>] A hashmap with module info
     # @param template [ModuleTemplate] The model describing a Generamba template used for code generation
     #
     # @return [String], [String] The generated file_name and body
-		def self.create_file(file, code_module, template)
+		def self.create_file(file, scope, template)
 			file_source = IO.read(template.template_path.join(file[TEMPLATE_FILE_PATH_KEY]))
 			Liquid::Template.file_system = Liquid::LocalFileSystem.new(template.template_path.join('snippets'), '%s.liquid')
 
@@ -20,28 +20,8 @@ module Generamba
       
 			file_basename = File.basename(file[TEMPLATE_FILE_NAME_KEY])
 
-			module_info = {
-					'name' => code_module.name,
-					'description' => code_module.description,
-					'project_name' => code_module.project_name,
-					'project_targets' => code_module.project_targets,
-					'test_targets' => code_module.test_targets
-			}
+			module_info = scope['module_info']
 
-			developer = {
-					'name' => code_module.author,
-					'company' => code_module.company
-			}
-
-			scope = {
-					'year' => code_module.year,
-					'date' => Time.now.strftime('%d/%m/%Y'),
-					'developer' => developer,
-					'module_info' => module_info,
-					'prefix' => code_module.prefix,
-					'custom_parameters' => code_module.custom_parameters
-			}
-      
 			module_info['file_basename'] = file_basename
 
 			file_name = filename_template.render(scope)
@@ -55,7 +35,7 @@ module Generamba
 		end
     
 		def self.file_name_template(file)
-			template_default_text = "{{ prefix }}{{ module_info.name }}{{ module_info.file_basename }}"
+			template_default_text = '{{ prefix }}{{ module_info.name }}{{ module_info.file_basename }}'
 			template_text = file[TEMPLATE_FILE_CUSTOM_NAME_KEY] || template_default_text
 			return Liquid::Template.parse(template_text)
 		end

--- a/lib/generamba/code_generation/module_template.rb
+++ b/lib/generamba/code_generation/module_template.rb
@@ -6,10 +6,18 @@ module Generamba
   class ModuleTemplate
     attr_reader :template_name, :template_path, :code_files, :test_files, :dependencies
 
-    def initialize(name)
+    def initialize(name, options = nil)
       spec_path = TemplateHelper.obtain_spec(name)
-      spec = YAML.load_file(spec_path)
-      
+
+      unless options
+        spec = YAML.load_file(spec_path)
+      else
+        spec_source = IO.read(spec_path)
+        spec_template = Liquid::Template.parse(spec_source)
+        spec_content = spec_template.render(options)
+        spec = YAML.load(spec_content)
+      end
+
       @code_files = spec[TEMPLATE_CODE_FILES_KEY]
       @test_files = spec[TEMPLATE_TEST_FILES_KEY]
       @template_name = spec[TEMPLATE_NAME_KEY]

--- a/lib/generamba/helpers/module_info_generator.rb
+++ b/lib/generamba/helpers/module_info_generator.rb
@@ -1,0 +1,32 @@
+module Generamba
+
+  class ModuleInfoGenerator
+    attr_reader :scope
+
+    def initialize(code_module)
+      module_info = {
+          'name' => code_module.name,
+          'description' => code_module.description,
+          'project_name' => code_module.project_name,
+          'project_targets' => code_module.project_targets,
+          'test_targets' => code_module.test_targets
+      }
+
+      developer = {
+          'name' => code_module.author,
+          'company' => code_module.company
+      }
+
+      @scope = {
+          'year' => code_module.year,
+          'date' => Time.now.strftime('%d/%m/%Y'),
+          'developer' => developer,
+          'module_info' => module_info,
+          'prefix' => code_module.prefix,
+          'custom_parameters' => code_module.custom_parameters
+      }
+    end
+
+  end
+
+end

--- a/lib/generamba/module_generator.rb
+++ b/lib/generamba/module_generator.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 
 require 'generamba/helpers/xcodeproj_helper.rb'
+require 'generamba/helpers/module_info_generator.rb'
 
 module Generamba
 
@@ -51,8 +52,8 @@ module Generamba
 			puts "Name: #{name}".green
 			puts "Module file path: #{code_module.module_file_path}".green
 			puts "Module group path: #{code_module.module_group_path}".green
-			puts !code_module.test_file_path ? '' : "Test file path: #{code_module.test_file_path}".green
-			puts !code_module.test_group_path ? '' : "Test group path: #{code_module.test_group_path}".green
+			puts "Test file path: #{code_module.test_file_path}".green if code_module.test_file_path
+			puts "Test group path: #{code_module.test_group_path}".green if code_module.test_group_path
 		end
 
 		def process_files_if_needed(files, name, code_module, template, project, targets, group_path, dir_path)
@@ -76,8 +77,10 @@ module Generamba
 
 				file_group = File.dirname(file[TEMPLATE_NAME_KEY])
 
+				module_info = ModuleInfoGenerator.new(code_module)
+
 				# Generating the content of the code file and it's name
-				file_name, file_content = ContentGenerator.create_file(file, code_module, template)
+				file_name, file_content = ContentGenerator.create_file(file, module_info.scope, template)
 				file_path = dir_path.join(file_group).join(file_name)
 
 				# Creating the file in the filesystem


### PR DESCRIPTION
Now available such parameters:

```
year - property from rambafile
date - generate module date
developer.name - developer name
developer.company - company name, property from rambafile
module_info.name - module name
module_info.description - module description
module_info.project_name - project name
module_info.project_targets - targets into which the module will be added
module_info.test_targets - targets into which the module tests will be added
prefix - project prefix
custom_parameters - custom parameters in format `key1:value1 key2:value2`
```

Example:

```
{% if custom_parameters.my_view == "true" %}
- {name: View/ViewInput.h, path: Code/MyView/view_input.h.liquid}
{% else %}
- {name: View/ViewInput.h, path: Code/View/view_input.h.liquid}
{% endif %}
```
