### PR TITLE
Bug fixes and refactoring

### DIFF
--- a/lib/generamba/cli/gen_command.rb
+++ b/lib/generamba/cli/gen_command.rb
@@ -16,8 +16,8 @@ module Generamba::CLI
     method_option :description, :aliases => '-d', :desc => 'Provides a full description to the module'
     method_option :author, :desc => 'Specifies the author name for generated module'
     method_option :project_targets, :desc => 'Specifies project targets for adding new module files'
-    method_option :module_file_path, :desc => 'Specifies a location in the filesystem for new files'
-    method_option :module_group_path, :desc => 'Specifies a location in Xcode groups for new files'
+    method_option :project_file_path, :desc => 'Specifies a location in the filesystem for new files'
+    method_option :project_group_path, :desc => 'Specifies a location in Xcode groups for new files'
     method_option :module_path, :desc => 'Specifies a location (both in the filesystem and Xcode) for new files'
     method_option :test_targets, :desc => 'Specifies project targets for adding new test files'
     method_option :test_file_path, :desc => 'Specifies a location in the filesystem for new test files'
@@ -25,7 +25,6 @@ module Generamba::CLI
     method_option :test_path, :desc => 'Specifies a location (both in the filesystem and Xcode) for new test files'
     method_option :custom_parameters, :type => :hash, :default => {}, :desc => 'Specifies extra parameters in format `key1:value1 key2:value2` for usage during code generation'
     def gen(module_name, template_name)
-
       does_rambafile_exist = Dir[RAMBAFILE_NAME].count > 0
 
       unless does_rambafile_exist
@@ -58,7 +57,7 @@ module Generamba::CLI
       DependencyChecker.check_all_required_dependencies_has_in_cartfile(template.dependencies, code_module.cartfile_path)
 
       project = XcodeprojHelper.obtain_project(code_module.xcodeproj_path)
-      module_group_already_exists = XcodeprojHelper.module_with_group_path_already_exists(project, code_module.module_group_path)
+      module_group_already_exists = XcodeprojHelper.module_with_group_path_already_exists(project, code_module.project_group_path)
 
       if module_group_already_exists
         replace_exists_module = yes?("#{module_name} module already exists. Replace? (yes/no)")

--- a/lib/generamba/code_generation/code_module.rb
+++ b/lib/generamba/code_generation/code_module.rb
@@ -39,7 +39,7 @@ module Generamba
       @project_name = rambafile[PROJECT_NAME_KEY]
 
       @product_module_name = rambafile[PRODUCT_MODULE_NAME_KEY]
-      @product_module_name = @project_name.gsub(C99IDENTIFIER, '_') if @project_name
+      @product_module_name = @project_name.gsub(C99IDENTIFIER, '_') if !@product_module_name && @project_name
 
       @xcodeproj_path = rambafile[XCODEPROJ_PATH_KEY]
 

--- a/lib/generamba/code_generation/code_module.rb
+++ b/lib/generamba/code_generation/code_module.rb
@@ -3,7 +3,7 @@ module Generamba
   SLASH_REGEX = /^\/|\/$/
   C99IDENTIFIER = /[^\w]/
 
-  PATH_TYPE_MODULE = 'module'
+  PATH_TYPE_PROJECT = 'project'
   PATH_TYPE_TEST = 'test'
 
   # Represents currently generating code module
@@ -17,8 +17,8 @@ module Generamba
                 :project_name,
                 :product_module_name,
                 :xcodeproj_path,
-                :module_file_path,
-                :module_group_path,
+                :project_file_path,
+                :project_group_path,
                 :test_file_path,
                 :test_group_path,
                 :project_targets,
@@ -37,10 +37,13 @@ module Generamba
 
       @prefix = rambafile[PROJECT_PREFIX_KEY]
       @project_name = rambafile[PROJECT_NAME_KEY]
-      @product_module_name = rambafile[PRODUCT_MODULE_NAME_KEY] || @project_name.gsub(C99IDENTIFIER, '_')
+
+      @product_module_name = rambafile[PRODUCT_MODULE_NAME_KEY]
+      @product_module_name = @project_name.gsub(C99IDENTIFIER, '_') if @project_name
+
       @xcodeproj_path = rambafile[XCODEPROJ_PATH_KEY]
 
-      setup_file_and_group_paths(rambafile[PROJECT_FILE_PATH_KEY], rambafile[PROJECT_GROUP_PATH_KEY], PATH_TYPE_MODULE)
+      setup_file_and_group_paths(rambafile[PROJECT_FILE_PATH_KEY], rambafile[PROJECT_GROUP_PATH_KEY], PATH_TYPE_PROJECT)
       setup_file_and_group_paths(rambafile[TEST_FILE_PATH_KEY], rambafile[TEST_GROUP_PATH_KEY], PATH_TYPE_TEST)
 
       @project_targets = [rambafile[PROJECT_TARGET_KEY]] if rambafile[PROJECT_TARGET_KEY]
@@ -57,16 +60,18 @@ module Generamba
       @project_targets = options[:project_targets].split(',') if options[:project_targets]
       @test_targets = options[:test_targets].split(',') if options[:test_targets]
       
-      setup_file_and_group_paths(options[:module_file_path], options[:module_group_path], PATH_TYPE_MODULE)
+      setup_file_and_group_paths(options[:project_file_path], options[:project_group_path], PATH_TYPE_PROJECT)
       setup_file_and_group_paths(options[:test_file_path], options[:test_group_path], PATH_TYPE_TEST)
 
       # The priority is given to `module_path` and 'test_path' options
-      setup_file_and_group_paths(options[:module_path], options[:module_path], PATH_TYPE_MODULE)
+      setup_file_and_group_paths(options[:module_path], options[:module_path], PATH_TYPE_PROJECT)
       setup_file_and_group_paths(options[:test_path], options[:test_path], PATH_TYPE_TEST)
 
       @podfile_path = rambafile[PODFILE_PATH_KEY] if rambafile[PODFILE_PATH_KEY]
       @cartfile_path = rambafile[CARTFILE_PATH_KEY] if rambafile[CARTFILE_PATH_KEY]
     end
+
+    private
 
     def setup_file_and_group_paths(file_path, group_path, path_type)
       if file_path || group_path

--- a/lib/generamba/helpers/gen_command_table_parameters_formatter.rb
+++ b/lib/generamba/helpers/gen_command_table_parameters_formatter.rb
@@ -7,11 +7,11 @@ module Generamba
     def self.prepare_parameters_for_displaying(code_module, template_name)
       params = {}
 
-      params['Targets'] = code_module.project_targets.join(',')
-      params['Module path'] = code_module.module_file_path
+      params['Targets'] = code_module.project_targets.join(',') if code_module.project_targets
+      params['Module path'] = code_module.project_file_path if code_module.project_file_path
 
-      if code_module.module_file_path != code_module.module_group_path
-        params['Module group path'] = code_module.module_group_path
+      if code_module.project_file_path != code_module.project_group_path
+        params['Module group path'] = code_module.project_group_path
       end
 
       params['Test targets'] = code_module.test_targets.join(',') if code_module.test_targets
@@ -23,7 +23,7 @@ module Generamba
 
       params['Template'] = template_name
 
-      if code_module.custom_parameters
+      unless code_module.custom_parameters.empty?
         params['Custom parameters'] = code_module.custom_parameters.to_json
       end
 

--- a/lib/generamba/helpers/module_info_generator.rb
+++ b/lib/generamba/helpers/module_info_generator.rb
@@ -8,6 +8,7 @@ module Generamba
           'name' => code_module.name,
           'description' => code_module.description,
           'project_name' => code_module.project_name,
+          'product_module_name' => code_module.product_module_name,
           'project_targets' => code_module.project_targets,
           'test_targets' => code_module.test_targets
       }

--- a/lib/generamba/helpers/module_validator.rb
+++ b/lib/generamba/helpers/module_validator.rb
@@ -2,18 +2,17 @@ module Generamba
   # Provides methods for validating module
   class ModuleValidator
 
+    TARGET_TYPE_PROJECT = 'project'
+    TARGET_TYPE_TEST = 'test'
+
     # Method validates module
     # @param code_module [CodeModule] The instance of CodeModule
     #
     # @return [Void]
     def validate(code_module)
       mandatory_fields = [COMPANY_KEY,
-                          PROJECT_PREFIX_KEY,
                           PROJECT_NAME_KEY,
-                          XCODEPROJ_PATH_KEY,
-                          PROJECT_TARGETS_KEY,
-                          'module_file_path',
-                          'module_group_path']
+                          XCODEPROJ_PATH_KEY]
 
       mandatory_fields.each do |field|
         unless code_module.instance_variable_get("@#{field}")
@@ -21,6 +20,65 @@ module Generamba
           exit
         end
       end
+
+      project_failure_fields = all_project_failure_fields(code_module)
+      test_failure_fields = all_test_failure_fields(code_module)
+      failure_fields = project_failure_fields + test_failure_fields
+
+      if failure_fields.count > 0
+        puts "Module is broken! *#{failure_fields}* field cannot be empty, because it is mandatory.".red
+        exit
+      end
+    end
+
+    private
+
+    # Method which return all project failure fields
+    # @param code_module [CodeModule] The instance of CodeModule
+    #
+    # @return [Array]
+    def all_project_failure_fields(code_module)
+      return [] if !code_module.project_targets && !code_module.project_file_path && !code_module.project_group_path
+
+      all_nil_mandatory_fields_for_target_type(TARGET_TYPE_PROJECT, code_module)
+    end
+
+    # Method which return all test failure fields
+    # @param code_module [CodeModule] The instance of CodeModule
+    #
+    # @return [Array]
+    def all_test_failure_fields(code_module)
+      return [] if !code_module.test_targets && !code_module.test_file_path && !code_module.test_group_path
+
+      all_nil_mandatory_fields_for_target_type(TARGET_TYPE_TEST, code_module)
+    end
+
+    # Method which return all failure fields for target_type
+    # @param target_type [String] "project" or "test"
+    # @param code_module [CodeModule] The instance of CodeModule
+    #
+    # @return [Array]
+    def all_nil_mandatory_fields_for_target_type(target_type, code_module)
+      fields = []
+
+      variable_name = "#{target_type}_targets"
+
+      unless code_module.instance_variable_get("@#{variable_name}")
+        target_const_value = Generamba.const_get(target_type.upcase + '_TARGET_KEY')
+        targets_const_value = Generamba.const_get(target_type.upcase + '_TARGETS_KEY')
+        fields.push(target_const_value)
+        fields.push(targets_const_value)
+      end
+
+      variable_name = "#{target_type}_file_path"
+      file_path_const_value = Generamba.const_get(target_type.upcase + '_FILE_PATH_KEY')
+      fields.push(file_path_const_value) unless code_module.instance_variable_get("@#{variable_name}")
+
+      variable_name = "#{target_type}_group_path"
+      group_path_const_value = Generamba.const_get(target_type.upcase + '_GROUP_PATH_KEY')
+      fields.push(group_path_const_value) unless code_module.instance_variable_get("@#{variable_name}")
+
+      fields
     end
 
   end

--- a/lib/generamba/helpers/rambafile_validator.rb
+++ b/lib/generamba/helpers/rambafile_validator.rb
@@ -9,97 +9,10 @@ module Generamba
       file_contents = open(path).read
       preferences = file_contents.empty? ? {} : YAML.load(file_contents).to_hash
 
-      mandatory_fields = [COMPANY_KEY,
-                          PROJECT_NAME_KEY,
-                          XCODEPROJ_PATH_KEY]
-
-      mandatory_fields.each do |field|
-        unless preferences[field]
-          puts "Rambafile is broken! *#{field}* field cannot be empty, because it is mandatory. Either add it manually, or run *generamba setup*.".red
-          exit
-        end
-      end
-
-      project_failure_fields = all_project_failure_fields(preferences)
-      test_failure_fields = all_test_failure_fields(preferences)
-      failure_fields = project_failure_fields + test_failure_fields
-
-      if failure_fields.count > 0
-        puts "Rambafile is broken! Cannot find any of #{failure_fields} fields, one of them is mandatory. Either add it manually, or run *generamba setup*.".red
-        exit
-      end
-
       unless preferences[TEMPLATES_KEY]
         puts "You can't run *generamba gen* without any templates installed. Add their declarations to a Rambafile and run *generamba template install*.".red
         exit
       end
-    end
-
-    private
-
-    # Method which return all project failure fields
-    # @param preferences [Hash] Converted Rambafile
-    #
-    # @return [Array]
-    def all_project_failure_fields(preferences)
-      file_path = preferences[PROJECT_FILE_PATH_KEY]
-      group_path = preferences[PROJECT_GROUP_PATH_KEY]
-
-      return [] if !file_path || !group_path
-
-      all_nil_mandatory_fields_for_target_type('project', preferences)
-    end
-
-    # Method which return all test failure fields
-    # @param preferences [Hash] Converted Rambafile
-    #
-    # @return [Array]
-    def all_test_failure_fields(preferences)
-      target = preferences[TEST_TARGET_KEY]
-      targets = preferences[TEST_TARGETS_KEY]
-      file_path = preferences[TEST_FILE_PATH_KEY]
-      group_path = preferences[TEST_GROUP_PATH_KEY]
-
-      has_test_fields = target || targets || file_path || group_path
-
-      return [] unless has_test_fields
-
-      all_nil_mandatory_fields_for_target_type('test', preferences)
-    end
-
-    # Method which return all failure fields for target_type
-    # @param target_type [String] "project" or "test"
-    # @param preferences [Hash] Converted Rambafile
-    #
-    # @return [Array]
-    def all_nil_mandatory_fields_for_target_type(target_type, preferences)
-      target_type = target_type.upcase
-
-      target_const_value = Generamba.const_get(target_type + '_TARGET_KEY')
-      targets_const_value = Generamba.const_get(target_type + '_TARGETS_KEY')
-
-      target = preferences[target_const_value]
-      targets = preferences[targets_const_value]
-
-      fields = []
-
-      if !target && (!targets || (targets && targets.count == 0))
-        fields.push(target_const_value)
-      end
-
-      file_path_const_value = Generamba.const_get(target_type + '_FILE_PATH_KEY')
-
-      unless preferences[file_path_const_value]
-        fields.push(file_path_const_value)
-      end
-
-      group_path_const_value = Generamba.const_get(target_type + '_GROUP_PATH_KEY')
-
-      unless preferences[group_path_const_value]
-        fields.push(group_path_const_value)
-      end
-
-      fields
     end
   end
 end

--- a/lib/generamba/module_generator.rb
+++ b/lib/generamba/module_generator.rb
@@ -13,36 +13,31 @@ module Generamba
 			project = XcodeprojHelper.obtain_project(code_module.xcodeproj_path)
 
 			# Configuring file paths
-			FileUtils.mkdir_p code_module.module_file_path
-
-			if code_module.test_file_path != nil
-				FileUtils.mkdir_p code_module.test_file_path
-			end
+			FileUtils.mkdir_p code_module.project_file_path if code_module.project_file_path
+			FileUtils.mkdir_p code_module.test_file_path if code_module.test_file_path
 
 			# Creating code files
-			puts('Creating code files...')
-			process_files_if_needed(template.code_files,
-									name,
-									code_module,
-									template,
-									project,
-									code_module.project_targets,
-									code_module.module_group_path,
-									code_module.module_file_path)
+			if code_module.project_targets && code_module.project_group_path && code_module.project_file_path
+				puts('Creating code files...')
+				process_files_if_needed(template.code_files,
+																code_module,
+																template,
+																project,
+																code_module.project_targets,
+																code_module.project_group_path,
+																code_module.project_file_path)
+			end
 
 			# Creating test files
-			included_tests = code_module.test_targets && code_module.test_group_path && code_module.test_file_path
-
-			if included_tests
+			if code_module.test_targets && code_module.test_group_path && code_module.test_file_path
 				puts('Creating test files...')
 				process_files_if_needed(template.test_files,
-										name,
-										code_module,
-										template,
-										project,
-										code_module.test_targets,
-										code_module.test_group_path,
-										code_module.test_file_path)
+																code_module,
+																template,
+																project,
+																code_module.test_targets,
+																code_module.test_group_path,
+																code_module.test_file_path)
 			end
 
 			# Saving the current changes in the Xcode project
@@ -50,13 +45,13 @@ module Generamba
 
 			puts 'Module successfully created!'
 			puts "Name: #{name}".green
-			puts "Module file path: #{code_module.module_file_path}".green
-			puts "Module group path: #{code_module.module_group_path}".green
+			puts "Project file path: #{code_module.project_file_path}".green if code_module.project_file_path
+			puts "Project group path: #{code_module.project_group_path}".green if code_module.project_group_path
 			puts "Test file path: #{code_module.test_file_path}".green if code_module.test_file_path
 			puts "Test group path: #{code_module.test_group_path}".green if code_module.test_group_path
 		end
 
-		def process_files_if_needed(files, name, code_module, template, project, targets, group_path, dir_path)
+		def process_files_if_needed(files, code_module, template, project, targets, group_path, dir_path)
 			# It's possible that current project doesn't test targets configured, so it doesn't need to generate tests.
 			# The same is for files property - a template can have only test or project files
 			if targets.count == 0 || files == nil || files.count == 0 || dir_path == nil || group_path == nil


### PR DESCRIPTION
1. Updated logic of rambafile and module validation. Now, only `company`, `project_name`, `xcodeproj_path` fields is mandatory.
2. Renamed `gen command` options `module_file_path -> project_file_path` and `module_group_path -> project_group_path`.
3. Added liquid property `product_module_name` for use in rambaspec files.
