### PR TITLE
[RESOLVED] Added ability use custom parameters in rambaspec #128

### DIFF
--- a/lib/generamba/cli/gen_command.rb
+++ b/lib/generamba/cli/gen_command.rb
@@ -45,7 +45,8 @@ module Generamba::CLI
       module_validator = ModuleValidator.new
       module_validator.validate(code_module)
 
-      template = ModuleTemplate.new(template_name)
+      module_info = ModuleInfoGenerator.new(code_module)
+      template = ModuleTemplate.new(template_name, module_info.scope)
 
       parameters = GenCommandTableParametersFormatter.prepare_parameters_for_displaying(code_module, template_name)
       PrintTable.print_values(


### PR DESCRIPTION
Now available such parameters:

```
year - property from rambafile
date - generate module date
developer.name - developer name
developer.company - company name, property from rambafile
module_info.name - module name
module_info.description - module description
module_info.project_name - project name
module_info.project_targets - targets into which the module will be added
module_info.test_targets - targets into which the module tests will be added
prefix - project prefix
custom_parameters - custom parameters in format `key1:value1 key2:value2`
```

Example:

```
{% if custom_parameters.my_view == "true" %}
- {name: View/ViewInput.h, path: Code/MyView/view_input.h.liquid}
{% else %}
- {name: View/ViewInput.h, path: Code/View/view_input.h.liquid}
{% endif %}
```
