### PR TITLE
Bump gems versions

### DIFF
--- a/generamba.gemspec
+++ b/generamba.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.add_runtime_dependency 'thor', '0.19.1'
-  spec.add_runtime_dependency 'xcodeproj', '1.5.4'
+  spec.add_runtime_dependency 'xcodeproj', '1.5.6'
   spec.add_runtime_dependency 'liquid', '4.0.0'
   spec.add_runtime_dependency 'git', '1.2.9.1'
   spec.add_runtime_dependency 'cocoapods-core', '1.4.0'

--- a/generamba.gemspec
+++ b/generamba.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.add_runtime_dependency 'thor', '0.19.1'
-  spec.add_runtime_dependency 'xcodeproj', '1.4.2'
+  spec.add_runtime_dependency 'xcodeproj', '1.5.4'
   spec.add_runtime_dependency 'liquid', '4.0.0'
   spec.add_runtime_dependency 'git', '1.2.9.1'
-  spec.add_runtime_dependency 'cocoapods-core', '1.0.1'
+  spec.add_runtime_dependency 'cocoapods-core', '1.4.0'
   spec.add_runtime_dependency 'terminal-table', '1.4.5'
 
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
### Notes:
- Some dependencies are not too relevant so we need to update them to maintain compatibility
### Changes:
- Bump xcodeproj version to 1.5.6
- Bump cocoapods-core version to 1.4.0