### PR TITLE
Update xcodeproj & cocoapods-core dependencies

### DIFF
--- a/generamba.gemspec
+++ b/generamba.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.add_runtime_dependency 'thor', '0.19.1'
-  spec.add_runtime_dependency 'xcodeproj', '1.5.6'
+  spec.add_runtime_dependency 'xcodeproj', '1.6.0'
   spec.add_runtime_dependency 'liquid', '4.0.0'
   spec.add_runtime_dependency 'git', '1.2.9.1'
-  spec.add_runtime_dependency 'cocoapods-core', '1.4.0'
+  spec.add_runtime_dependency 'cocoapods-core', '1.5.3'
   spec.add_runtime_dependency 'terminal-table', '1.4.5'
 
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
This bumps xcodeproj to 1.6.0 (allowing for Xcode 10 support)  and cocoapods-core to 1.5.3.