### PR TITLE
Resolve Cocoapods Dependency hell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ rvm:
 
 before_install:
   - gem update --system --no-doc --no-ri
-  - gem install bundler -v 1.17.3 --no-doc --no-ri
+  - gem install bundler -v 1.17.3 --no-document
 
 script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ rvm:
 
 before_install:
   - gem update --system --no-doc --no-ri
-  - gem install bundler --no-doc --no-ri
+  - gem install bundler -v 1.17.3 --no-doc --no-ri
 
 script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.3.1
 
 before_install:
-  - gem update --system --no-doc --no-ri
+  - gem update --system --no-document
   - gem install bundler -v 1.17.3 --no-document
 
 script: bundle exec rake

--- a/generamba.gemspec
+++ b/generamba.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.add_runtime_dependency 'thor', '0.19.1'
-  spec.add_runtime_dependency 'xcodeproj', '1.5.6'
+  spec.add_runtime_dependency 'xcodeproj', '1.7.0'
   spec.add_runtime_dependency 'liquid', '4.0.0'
   spec.add_runtime_dependency 'git', '1.2.9.1'
-  spec.add_runtime_dependency 'cocoapods-core', '1.4.0'
+  spec.add_runtime_dependency 'cocoapods-core', '1.5.3'
   spec.add_runtime_dependency 'terminal-table', '1.4.5'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/generamba.gemspec
+++ b/generamba.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'xcodeproj', '>= 1.5.0', '< 2.0.0'
   spec.add_runtime_dependency 'liquid', '4.0.0'
   spec.add_runtime_dependency 'git', '1.2.9.1'
-  spec.add_runtime_dependency 'cocoapods-core', '1.5.3'
+  spec.add_runtime_dependency 'cocoapods-core', '>= 1.4.0', '< 2.0.0'
   spec.add_runtime_dependency 'terminal-table', '1.4.5'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/generamba.gemspec
+++ b/generamba.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.add_runtime_dependency 'thor', '0.19.1'
-  spec.add_runtime_dependency 'xcodeproj', '1.7.0'
+  spec.add_runtime_dependency 'xcodeproj', '>= 1.5.0', '< 2.0.0'
   spec.add_runtime_dependency 'liquid', '4.0.0'
   spec.add_runtime_dependency 'git', '1.2.9.1'
   spec.add_runtime_dependency 'cocoapods-core', '1.5.3'


### PR DESCRIPTION
This sets xcodeproj from 1.5.0 to 2.0.0 and cocoapods-core from 1.5.0 to 2.0.0. 
Now we can get rid of problems with dependencies in bundler for a long time