### PR TITLE
Xcodeproj dependency versions fix #225

### DIFF
--- a/generamba.gemspec
+++ b/generamba.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.add_runtime_dependency 'thor', '0.19.1'
-  spec.add_runtime_dependency 'xcodeproj', '>= 1.5.0', '< 2.0.0'
+  spec.add_runtime_dependency 'xcodeproj', '>= 1.6.0', '< 2.0.0'
   spec.add_runtime_dependency 'liquid', '4.0.0'
   spec.add_runtime_dependency 'git', '1.2.9.1'
   spec.add_runtime_dependency 'cocoapods-core', '>= 1.4.0', '< 2.0.0'


### PR DESCRIPTION
For correct work with Xcode 10 generated projects we need at least `xcodeproj` gem version 1.6.0, so if you already have locally installed gem `xcodeproj` versions between 1.5.0 and <1.6.0, you will got the same error as described in #225