### PR TITLE
Option for generating groups without folders

### DIFF
--- a/lib/generamba/code_generation/code_module.rb
+++ b/lib/generamba/code_generation/code_module.rb
@@ -25,7 +25,8 @@ module Generamba
                 :test_targets,
                 :podfile_path,
                 :cartfile_path,
-                :custom_parameters
+                :custom_parameters,
+                :create_logical_groups
 
     def initialize(name, rambafile, options)
       # Base initialization
@@ -69,6 +70,7 @@ module Generamba
 
       @podfile_path = rambafile[PODFILE_PATH_KEY] if rambafile[PODFILE_PATH_KEY]
       @cartfile_path = rambafile[CARTFILE_PATH_KEY] if rambafile[CARTFILE_PATH_KEY]
+      @create_logical_groups = rambafile[CREATE_LOGICAL_GROUPS_KEY] if rambafile[CREATE_LOGICAL_GROUPS_KEY]
     end
 
     private

--- a/lib/generamba/constants/rambafile_constants.rb
+++ b/lib/generamba/constants/rambafile_constants.rb
@@ -18,6 +18,8 @@ module Generamba
   TEST_TARGETS_KEY = 'test_targets'
   TEST_FILE_PATH_KEY = 'test_file_path'
   TEST_GROUP_PATH_KEY = 'test_group_path'
+  
+  CREATE_LOGICAL_GROUPS_KEY = 'create_logical_groups'
 
   PODFILE_PATH_KEY = 'podfile_path'
   CARTFILE_PATH_KEY = 'cartfile_path'

--- a/lib/generamba/module_generator.rb
+++ b/lib/generamba/module_generator.rb
@@ -66,7 +66,7 @@ module Generamba
 					file_group = dir_path.join(directory_name)
 
 					FileUtils.mkdir_p file_group
-					XcodeprojHelper.add_group_to_project(project, group_path, dir_path, directory_name)
+					XcodeprojHelper.add_group_to_project(project, group_path, dir_path, directory_name, code_module.create_logical_groups)
 
 					next
 				end
@@ -79,10 +79,11 @@ module Generamba
 				# Generating the content of the code file and it's name
 				file_name, file_content = ContentGenerator.create_file(file, module_info.scope, template)
 				file_path = dir_path
-				file_path = file_path.join(file_group) if file_group
+                file_path = file_path.join(file_group) if (file_group && !code_module.create_logical_groups)
 				file_path = file_path.join(file_name) if file_name
 
 				# Creating the file in the filesystem
+
 				FileUtils.mkdir_p File.dirname(file_path)
 				File.open(file_path, 'w+') do |f|
 					f.write(file_content)
@@ -97,7 +98,9 @@ module Generamba
 																												dir_path,
 																												file_group,
 																												file_name,
-																												file_is_resource)
+																												file_is_resource,
+
+                                                                             code_module.create_logical_groups)
 			end
 		end
 	end


### PR DESCRIPTION
An option to generate "logical" groups in xcode and not the actual folders in the filesystem.

Specifically see something like this:
<img width="240" alt="Screen Shot 2019-07-11 at 11 16 59 AM" src="https://user-images.githubusercontent.com/9692155/61019630-72228980-a3cd-11e9-8fa3-6f3a10d479b4.png">

But in the filesystem it's like this:
<img width="240" alt="Screen Shot 2019-07-11 at 11 21 31 AM" src="https://user-images.githubusercontent.com/9692155/61019800-0db3fa00-a3ce-11e9-9d88-526133725fdf.png">


