### PR TITLE
bump ruby-git version to fix security vulnerability

### DIFF
--- a/generamba.gemspec
+++ b/generamba.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'thor', '0.19.1'
   spec.add_runtime_dependency 'xcodeproj', '>= 1.6.0', '< 2.0.0'
   spec.add_runtime_dependency 'liquid', '4.0.0'
-  spec.add_runtime_dependency 'git', '1.2.9.1'
+  spec.add_runtime_dependency 'git', '>=1.11.0'
   spec.add_runtime_dependency 'cocoapods-core', '>= 1.4.0', '< 2.0.0'
   spec.add_runtime_dependency 'terminal-table', '1.4.5'
 


### PR DESCRIPTION
ruby-git `<1.11.0` are vulnerable to Command Injection via git argument injection.
For more information, see https://github.com/ruby-git/ruby-git/pull/569.